### PR TITLE
Specify ava version, update test to not depend on babel, and change the way to convert to number

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+yarn.lock

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 var numberIsNan = require('number-is-nan');
 
 module.exports = Math.sign || function (x) {
-	x = Number(x);
+	x = +x;
 
 	if (x === 0 || numberIsNan(x)) {
 		return x;

--- a/package.json
+++ b/package.json
@@ -36,6 +36,6 @@
     "number-is-nan": "^1.0.0"
   },
   "devDependencies": {
-    "ava": "*"
+    "ava": "3.2.0"
   }
 }

--- a/test.js
+++ b/test.js
@@ -1,29 +1,29 @@
-import test from 'ava';
-import numberIsNan from 'number-is-nan';
+const test = require("ava");
+const numberIsNan = require("number-is-nan");
 
 Math.sign = undefined;
-const fn = require('./');
+const fn = require("./");
 
-test(t => {
+test("Testing Math Sign", t => {
 	t.is(fn(0), 0);
 	t.is(fn(100.1), 1);
 	t.is(fn(-0), -0);
 	t.is(fn(5), 1);
 	t.is(fn(-5), -1);
-	t.is(fn('-5'), -1);
+	t.is(fn("-5"), -1);
 	t.true(numberIsNan(fn(NaN)));
-	t.true(numberIsNan(fn('foo')));
+	t.true(numberIsNan(fn("foo")));
 	t.true(numberIsNan(fn()));
 	t.true(numberIsNan(fn([1, 1])));
-	t.is(String(1 / fn(0)), 'Infinity');
-	t.is(String(1 / fn(-0)), '-Infinity');
+	t.is(String(1 / fn(0)), "Infinity");
+	t.is(String(1 / fn(-0)), "-Infinity");
 	t.is(fn([-100.1]), -1);
-	t.is(fn({toString: () => '100'}), 1);
-	t.is(fn({toString: () => 100}), 1);
-	t.is(fn({valueOf: () => -1.1}), -1);
-	t.is(fn({valueOf: () => '-1.1'}), -1);
+	t.is(fn({ toString: () => "100" }), 1);
+	t.is(fn({ toString: () => 100 }), 1);
+	t.is(fn({ valueOf: () => -1.1 }), -1);
+	t.is(fn({ valueOf: () => "-1.1" }), -1);
 	t.is(fn(Infinity), 1);
 	t.is(fn(-Infinity), -1);
-	t.is(fn('Infinity'), 1);
-	t.is(fn('-Infinity'), -1);
+	t.is(fn("Infinity"), 1);
+	t.is(fn("-Infinity"), -1);
 });


### PR DESCRIPTION
I have:
1. Specified version of `ava` to avoid crashing of `test.js`.
2. Updated `test.js` to work without `babel`.
3. Changed the following:
```diff
- x = Number(x)
+ x = +x
```
Since it is the fastest way to convert to a number.

The following code is not implemented, but could be handy:
Because of it, the following if statement can be changed as such:
```diff
- if(x === 0 || numberIsNaN(x) {
+if(!x) {
  return x;
}
```
Since `+x` guarantees `x` to be of type `number` and both `0` and `NaN` are `falsy`.